### PR TITLE
PEP 622: fix broken internal link

### DIFF
--- a/pep-0622.rst
+++ b/pep-0622.rst
@@ -601,7 +601,7 @@ The procedure is as following:
   ``__match_args__``, else the match raises ``ImpossibleMatchError``.
 
 Such a protocol favors simplicity of implementation over flexibility and
-performance. For other considered alternatives, see `extended matching`_.
+performance. For other considered alternatives, see `extended matching protocol`_.
 
 For the most commonly-matched built-in types (``bool``,
 ``bytearray``, ``bytes``, ``dict``, ``float``,


### PR DESCRIPTION
The link target was broken in 430718e
